### PR TITLE
Simplify logic and make pin prop reactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Masked PIN input components for svelte.
+## Masked PIN input component for svelte
 
-see the [demo](https://svelte-test.rebotak.now.sh/)
+[Demo](https://svelte-test.rebotak.now.sh/)
 
-### Install:
+### Install
 
 ```sh
 
@@ -10,31 +10,24 @@ npm i -s svelte-pin
 
 ```
 
-### Usage:
+### Usage
 
 ```js
 
 <script>
-
-import PinInput from 'svelte-pin';
-
-let value;
-
+  import PinInput from 'svelte-pin';
+  let value;
 </script>
 
-
-
 <PinInput size={6} bind:pin={value} />
-
 <h1>PIN: {value}</h1>
-
 
 
 ```
 
 ### Props:
 
-| Prop | Default value | Description                                              |
-| ---- | ------------- | -------------------------------------------------------- |
-| pin  | ''            | Value of the input. need to bind to component's variable |
-| size | 6             | Length of the pin input                                  |
+| Prop | Default value | Description              |
+| ---- | ------------- | ------------------------ |
+| pin  | ''            | Value of the input       |
+| size | 6             | Length of the pin input  |

--- a/index.svelte
+++ b/index.svelte
@@ -1,112 +1,63 @@
 <script>
   import { onMount } from "svelte";
-
   const KEYBOARD = {
     BACKSPACE: 8,
     DELETE: 46,
     ANDROID_BACKSPACE: 229,
   };
-
-  let inputs = [0];
-  let pins = {};
-
-  export let pin;
+  let inputs = [];
+  export let pin = '';
   export let size = 6;
-
-  onMount(async () => {
-    inputs = await createArray(size);
-    pins = await createValueSlot(inputs);
-    pin = calcPin(pins);
-    document.getElementById("pin0").focus();
-  });
-
-  const calcPin = (pins) => {
-    if (Object.values(pins).length) {
-      return Object.values(pins).join("");
-    } else return "";
-  };
+  export let disabled = false;
 
   const isKeyDelete = (key) => {
-    let result =
-      key === KEYBOARD.BACKSPACE ||
-      key === KEYBOARD.DELETE ||
-      key === KEYBOARD.ANDROID_BACKSPACE;
-    return result;
+    return key === KEYBOARD.BACKSPACE
+      || key === KEYBOARD.DELETE
+      || key === KEYBOARD.ANDROID_BACKSPACE;
   };
-
-  const deleteCurrentPin = (i) => {
-    pins[i] = "";
-    pin = calcPin(pins);
-  };
-
-  const changeHandler = function (e, i) {
+  const onKeyDown = (e, currentIndex) => {
     const current = document.activeElement;
-    const items = [...document.getElementsByClassName("pin-item")];
-    const currentIndex = items.indexOf(current);
-    let newIndex;
-
-    let regx = new RegExp(/^\d+$/);
-    // backspace pressed on first digit
+    let isDigit = new RegExp(/^\d+$/);
     if (isKeyDelete(e.keyCode) && currentIndex === 0) {
-      // remove value of fist digit, end.
-      deleteCurrentPin(i);
-      return;
+      return pin = '';
+    } else if (isKeyDelete(e.keyCode) && currentIndex !== 0) {
+      pin = pin.slice(0, currentIndex - 1);
+      const newIndex = Math.max(0, currentIndex - 1);
+      return inputs[newIndex].focus();
     }
-    // pressing backspace not on the first digit
-    else if (isKeyDelete(e.keyCode) && currentIndex !== 0) {
-      // remove value of current digit & move to previous digit
-      deleteCurrentPin(i);
-      newIndex = (currentIndex + items.length - 1) % items.length;
-    } else {
-      // if not backspace pressed, set indext to next digit
-      newIndex = (currentIndex + 1) % items.length;
-    }
-    // test value. if number, change value of current digit
-    if (regx.test(e.key)) {
-      pins[i] = e.key;
-      pin = calcPin(pins);
 
+    if (isDigit.test(e.key)) {
+      pin = pin.slice(0, currentIndex);
+      pin += e.key;
       current.blur();
+      if (currentIndex !== inputs.length - 1 || isKeyDelete(e.keyCode)) {
+        const newIndex = (currentIndex + 1) % inputs.length;
+        inputs[newIndex].focus();
+      }
     }
-    // if not last digit, move cursor
-    if (currentIndex !== items.length - 1 || isKeyDelete(e.keyCode)) {
-      items[newIndex].focus();
-    }
-    return;
-  };
-  const createArray = (size) => {
-    return new Array(size);
-  };
-  const createValueSlot = (arr) => {
-    return arr.reduce((obj, item) => {
-      return {
-        ...obj,
-        [item]: "",
-      };
-    }, {});
   };
 </script>
 
 <style>
   .pin-input {
+    width: 100%;
     position: relative;
     margin: 0 auto;
+
+    display: flex;
     align-items: center;
     justify-content: center;
-    width: 100%;
-    display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
   }
   input {
     width: 32px;
-    -webkit-text-security: disc;
-    border: none;
-    text-align: center;
-    border-bottom: 1px solid black;
-    margin: 0 4px;
-    border-radius: 0;
     height: 40px;
+    border: none;
+    border-bottom: 1px solid black;
+    border-radius: 0;
+    margin: 0 4px;
+    text-align: center;
     background: transparent;
   }
   input:focus {
@@ -115,17 +66,18 @@
 </style>
 
 <div class="pin-input">
-  {#if inputs.length}
-    {#each inputs as item, i}
+  {#if size}
+    {#each Array(size) as o, i}
       <input
-        bind:value={pins[i]}
-        maxLength="1"
+        bind:this={inputs[i]}
+        on:keydown|preventDefault={(event) => onKeyDown(event, i)}
         class="pin-item"
-        id={`pin${i}`}
+        disabled={disabled}
+        value={pin[i] || ''}
+        maxLength="1"
         type="tel"
         pattern="\d{1}"
         maxlength="1"
-        on:keydown|preventDefault={(event) => changeHandler(event, i)}
         placeholder="" />
     {/each}
   {/if}


### PR DESCRIPTION
Changing the pin prop now triggers a rerender

Simplify the logic and pass through disable as a prop

(Might want to consider just passing down $$props instead, although this
is not recommended by the Svelte team due to optimization issues.)